### PR TITLE
Refactor store replication messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,38 +104,19 @@ Pinion is still on its infancy and you might need debug info or a more detailed 
 
 ### Requests
 
-#### `PIN_STORE`
-
-Opens a store, keeps listening to it for a pre-defined timeout and pin its content until the time is up or it's replicated.
-
-##### Parameters
-
-1.  `address` - An orbit-db-store address. Emits a `pinned` event passing the store address back.
-
-##### Payload example
-
-```js
- {
-   type: 'PIN_STORE',
-   payload: { address: '/orbitdb/Qma=/my-store' },
- };
-```
-
----
-
-#### `LOAD_STORE`
+#### `REPLICATE`
 
 Opens a store, loads it and keep listening to it until it's being cleaned up by the LRU cache.
 
 ##### Parameters
 
-1.  `address` - An orbit-db-store address. Emits a `loadedStore` event passing the store address back.
+1.  `address` - An orbit-db-store address.
 
 ##### Payload example
 
 ```js
  {
-   type: 'LOAD_STORE',
+   type: 'REPLICATE',
    payload: { address: '/orbitdb/Qma=/my-store' },
  };
 ```
@@ -165,7 +146,7 @@ Request the IPFS node to pin the content hash.
 
 ##### `HAVE_HEADS`
 
-Published when the pinner has opened a store and it's ready
+Published when the pinner has opened a store and it's ready. It will contain the count of heads that the pinner has for this store.
 
 ##### Payload example
 
@@ -178,48 +159,6 @@ Published when the pinner has opened a store and it's ready
      count: 100,
      timestamp: 10010203993
   },
- }
-```
-
----
-
-##### `ACK`
-
-Published on every incoming message, acknowledging we got it with either the `ipfsHash` or the orbit-db store address
-
-##### Payload example
-
-```js
- {
-   type: 'ACK',
-   to: 'Qma=',
-   payload: {
-     sender: 'Qma=',
-     actionType: 'PIN_STORE',
-     address: '/orbitdb/Qma=/my-store',
-     ipfsHash: 'Qma=...',
-     timestamp: 10010203993
-   },
- }
-```
-
----
-
-##### `REPLICATED`
-
-Published after a store is fully replicated
-
-##### Payload example
-
-```js
- {
-   type: 'REPLICATED',
-   to: '/orbitdb/Qma=/my-store',
-   payload: {
-     address: '/orbitdb/Qma=/my-store',
-     count: 100,
-     timestamp: 10010203993
-   },
  }
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ipfsd-js": "docker run -v $(pwd)/data-js:/root/.jsipfs -p 4001:4001 -p 4003:4003 -p 127.0.0.1:8080:8080 -p 127.0.0.1:5001:5001 joincolony/js-ipfs:latest daemon --enable-pubsub-experiment",
     "ipfsd-go": "docker run -v $(pwd)/data-go:/data/ipfs -p 4001:4001 -p 4003:4003 -p 127.0.0.1:8080:8080 -p 127.0.0.1:5001:5001 ipfs/go-ipfs:v0.4.20 daemon --enable-pubsub-experiment",
     "postinstall": "scripts/postinstall.sh",
-    "start": "tsc && bin/index.js",
+    "start": "yarn build && bin/index.js",
     "test:ci": "wait-on tcp:$CI_API_PORT && yarn test --tap | tap-xunit > reports/ava/ava-results.xml"
   },
   "keywords": [

--- a/src/IPFSNode.ts
+++ b/src/IPFSNode.ts
@@ -29,9 +29,9 @@ class IPFSNode {
 
   private readonly room: string;
 
-  private id: string = '';
-
   private roomMonitor!: PeerMonitor;
+
+  public id: string = '';
 
   constructor(events: EventEmitter, ipfsDaemonURL: string, room: string) {
     this.events = events;

--- a/src/Pinion.ts
+++ b/src/Pinion.ts
@@ -7,6 +7,7 @@
 import assert = require('assert');
 import debug = require('debug');
 import EventEmitter = require('events');
+import { Entry } from 'ipfs-log';
 
 import IPFS from 'ipfs';
 
@@ -17,8 +18,8 @@ import IPFSNode from './IPFSNode';
 
 const logError = debug('pinner:error');
 const logDebug = debug('pinner:debug');
-const { LOAD_STORE, PIN_STORE, PIN_HASH } = ClientActions;
-const { ACK, HAVE_HEADS, REPLICATED } = PinnerActions;
+const { REPLICATE, PIN_HASH } = ClientActions;
+const { HAVE_HEADS } = PinnerActions;
 
 interface ClientActionPayload {
   ipfsHash?: string;
@@ -28,6 +29,12 @@ interface ClientActionPayload {
 export interface ClientAction {
   type: ClientActions;
   payload: ClientActionPayload;
+}
+
+interface ReplicationEvent {
+  address: string;
+  heads: Entry[];
+  peer: string;
 }
 
 interface ReplicationMessagePayload {
@@ -51,8 +58,6 @@ interface Options {
 }
 
 class Pinion {
-  private id: string = '';
-
   private readonly ipfsNode: IPFSNode;
 
   private readonly storeManager: StoreManager;
@@ -81,7 +86,7 @@ class Pinion {
 
     this.events
       .on('pubsub:message', this.handleMessage)
-      .on('stores:pinned', this.publishReplicated);
+      .on('stores:replicated', this.publishHeads);
   }
 
   public get openStores(): number {
@@ -101,92 +106,46 @@ class Pinion {
     if (!action) return;
     const { type, payload } = action;
     const { ipfsHash, address } = payload;
-    // Send ACK
-    try {
-      await this.publishAck(type, message.from, address, ipfsHash);
-    } catch (caughtError) {
-      logError(caughtError);
-    } finally {
-      switch (type) {
-        case PIN_HASH: {
-          if (!ipfsHash) {
-            logError('PIN_HASH: no ipfsHash given');
-            return;
-          }
-          this.ipfsNode.pinHash(ipfsHash).catch(logError);
-          break;
+    switch (type) {
+      case PIN_HASH: {
+        if (!ipfsHash) {
+          logError('PIN_HASH: no ipfsHash given');
+          return;
         }
-        case PIN_STORE: {
-          if (!address) {
-            logError('PIN_STORE: no address given');
-            return;
-          }
-          this.storeManager.pinStore(address).catch(logError);
-          break;
-        }
-        case LOAD_STORE: {
-          if (!address) {
-            logError('LOAD_STORE: no address given');
-            return;
-          }
-          this.storeManager.loadStore(address).catch(logError);
-          break;
-        }
-        default:
-          break;
+        this.ipfsNode.pinHash(ipfsHash).catch(logError);
+        break;
       }
+      case REPLICATE: {
+        if (!address) {
+          logError('PIN_STORE: no address given');
+          return;
+        }
+        this.storeManager.loadStore(address).catch(logError);
+        break;
+      }
+      default:
+        break;
     }
   };
 
-  private publishReplicated = (
-    storeAddress: string,
-    heads: number,
-  ): Promise<void> => {
-    return this.ipfsNode.publish<'REPLICATED', ReplicationMessagePayload>({
-      type: REPLICATED,
-      to: storeAddress,
+  private publishHeads = async ({
+    address,
+    heads,
+  }: ReplicationEvent): Promise<void> => {
+    return this.ipfsNode.publish<'HAVE_HEADS', ReplicationMessagePayload>({
+      type: HAVE_HEADS,
+      to: address,
       payload: {
-        address: storeAddress,
-        count: heads,
+        address,
+        count: heads.length,
         timestamp: Date.now(),
       },
     });
   };
 
-  private publishHeads(storeAddress: string, heads: number): Promise<void> {
-    return this.ipfsNode.publish<'HAVE_HEADS', ReplicationMessagePayload>({
-      type: HAVE_HEADS,
-      to: storeAddress,
-      payload: {
-        address: storeAddress,
-        count: heads,
-        timestamp: Date.now(),
-      },
-    });
-  }
-
-  private publishAck(
-    acknowledgedAction: ClientActions,
-    sender: string,
-    storeAddress?: string,
-    ipfsHash?: string,
-  ): Promise<void> {
-    return this.ipfsNode.publish<'ACK', AckMessagePayload>({
-      type: ACK,
-      to: sender,
-      payload: {
-        acknowledgedAction,
-        sender,
-        address: storeAddress,
-        ipfsHash,
-        timestamp: Date.now(),
-      },
-    });
-  }
-
   public async start(): Promise<void> {
-    logDebug(`Pinner id: ${this.id}`);
     await this.ipfsNode.start();
+    logDebug(`Pinner id: ${this.ipfsNode.id}`);
     await this.storeManager.start();
   }
 

--- a/src/StoreManager.ts
+++ b/src/StoreManager.ts
@@ -81,8 +81,14 @@ class StoreManager {
       storeAddress: string,
       heads: Entry[],
     ): void => {
-      // @todo check why peer is empty!!
-      log(`Store "${address}" replicated for ${peer}`);
+      // @todo The `peer` argument sometimes is undefined. It might not be a big
+      // problem as the replication works properly. But we should keep an eye on
+      // it.
+      log(
+        `Store "${address}" replicated for ${peer}. Got ${
+          heads.length
+        } new heads.`,
+      );
       this.events.emit('stores:replicated', { address, heads, peer });
     };
     const store = await this.orbitNode.open(address, {
@@ -110,8 +116,14 @@ class StoreManager {
     return this.orbitNode.disconnect();
   }
 
-  public async loadStore(address: string): Promise<OrbitDBStore | void> {
-    return this.cache.load(address);
+  public async loadStore(address: string): Promise<number> {
+    const store = await this.cache.load(address);
+    if (store) {
+      // This is a private API but there's no other way to access this atm
+      // eslint-disable-next-line dot-notation
+      return store['_oplog'].length;
+    }
+    return 0;
   }
 
   public async closeStore(address: string): Promise<OrbitDBStore | void> {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,11 +1,8 @@
 export enum ClientActions {
-  LOAD_STORE = 'LOAD_STORE',
-  PIN_STORE = 'PIN_STORE',
+  REPLICATE = 'REPLICATE',
   PIN_HASH = 'PIN_HASH',
 }
 
 export enum PinnerActions {
-  ACK = 'ACK',
   HAVE_HEADS = 'HAVE_HEADS',
-  REPLICATED = 'REPLICATED',
 }

--- a/types/ipfs-log/index.d.ts
+++ b/types/ipfs-log/index.d.ts
@@ -1,8 +1,14 @@
+/* eslint @typescript-eslint/interface-name-prefix: 0 */
+
 declare module 'ipfs-log' {
   import IPFS from 'ipfs';
   import IdentityProvider, { Identity } from 'orbit-db-identity-provider';
 
   type EntryDataPrimitive = string | number | Buffer | Date;
+
+  interface IPFSLog {
+    readonly length: number;
+  }
 
   namespace IPFSLog {
     // It has to be stringifyable. Maybe we can do better

--- a/types/orbit-db-store/index.d.ts
+++ b/types/orbit-db-store/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'orbit-db-store' {
   import EventEmitter from 'events';
   import IPFS from 'ipfs';
+  import IPFSLog from 'ipfs-log';
   import { Identity } from 'orbit-db-identity-provider';
   import { EntryData } from 'ipfs-log';
   import { AccessController } from 'orbit-db-access-controllers';
@@ -17,7 +18,7 @@ declare module 'orbit-db-store' {
       },
     );
 
-    private _oplog: { _length: number };
+    private _oplog: IPFSLog;
     private _addOperation(data: EntryData): void;
 
     public readonly address: OrbitDBStore.StoreAddress;


### PR DESCRIPTION
## Description

This PR simplifies a lot of the actions for the pinner. We removed some of the actions and replaced them with new, simpler ones. Also the pinner can now communicate the number of heads it has on a certain store.

**New stuff** ✨

* Nothing new ☹️ 

**Changes** 🏗

* We just have a `REPLICATE` action now instead of `PIN_STORE` and `LOAD_STORE` (because it's basically doing the same thing. The pinner will always reply with a `HAVE_HEADS` answer telling the requester how many heads are available on the pinner.

**Deletions** ⚰️

* Removed all of the `ACK` responses as we don't need them for now as well as the `REPLICATED` response as it is unnecessary as well (or: unreliable).

## TODO

- [ ] Adjust Readme