### PR TITLE
Presence announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,25 +142,6 @@ Request the IPFS node to pin the content hash.
 
 ---
 
-#### `ANNOUNCE_CLIENT`
-
-Announce a client joining the room explicitly.
-
-##### Parameters
-
-1.  `ipfsId` - IPFS ID of the client peer.
-
-##### Payload example
-
-```js
- {
-   type: 'ANNOUNCE_CLIENT',
-   payload: { ipfsId: 'Qm...' },
- };
-```
-
----
-
 #### Responses
 
 ##### `HAVE_HEADS`
@@ -191,7 +172,6 @@ Published when the pinner has started, or in response to an `ANNOUNCE_CLIENT` me
 ```js
  {
    type: 'ANNOUNCE_PINNER',
-   to: 'Qm...', // this is only included as a response to an `ANNOUNCE_CLIENT` message
    payload: {
      ipfsId: 'Qm...',
   },

--- a/README.md
+++ b/README.md
@@ -142,6 +142,25 @@ Request the IPFS node to pin the content hash.
 
 ---
 
+#### `ANNOUNCE_CLIENT`
+
+Announce a client joining the room explicitly.
+
+##### Parameters
+
+1.  `address` - Address of the client peer.
+
+##### Payload example
+
+```js
+ {
+   type: 'PIN_HASH',
+   payload: { address: 'Qma=...' },
+ };
+```
+
+---
+
 #### Responses
 
 ##### `HAVE_HEADS`
@@ -158,6 +177,23 @@ Published when the pinner has opened a store and it's ready. It will contain the
      address: '/orbitdb/Qma=/my-store/<signature>',
      count: 100,
      timestamp: 10010203993
+  },
+ }
+```
+
+
+##### `ANNOUNCE_PINNER`
+
+Published when the pinner has started, or in response to an `ANNOUNCE_CLIENT` message.
+
+##### Payload example
+
+```js
+ {
+   type: 'ANNOUNCE_PINNER',
+   to: 'Qm...', // this is only included as a response
+   payload: {
+     address: 'Qm...',
   },
  }
 ```

--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ Announce a client joining the room explicitly.
 
 ##### Parameters
 
-1.  `address` - Address of the client peer.
+1.  `ipfsId` - IPFS ID of the client peer.
 
 ##### Payload example
 
 ```js
  {
-   type: 'PIN_HASH',
-   payload: { address: 'Qma=...' },
+   type: 'ANNOUNCE_CLIENT',
+   payload: { ipfsId: 'Qm...' },
  };
 ```
 
@@ -191,9 +191,9 @@ Published when the pinner has started, or in response to an `ANNOUNCE_CLIENT` me
 ```js
  {
    type: 'ANNOUNCE_PINNER',
-   to: 'Qm...', // this is only included as a response
+   to: 'Qm...', // this is only included as a response to an `ANNOUNCE_CLIENT` message
    payload: {
-     address: 'Qm...',
+     ipfsId: 'Qm...',
   },
  }
 ```

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "tap-xunit": "2.4.1",
     "ts-node": "8.2.0",
     "typescript": "3.5.1",
-    "wait-on": "3.2.0"
+    "wait-on": "^3.3.0-beta.0"
   },
   "dependencies": {
     "debug": "^4.1.0",

--- a/src/IPFSNode.ts
+++ b/src/IPFSNode.ts
@@ -15,7 +15,7 @@ import PeerMonitor = require('ipfs-pubsub-peer-monitor');
 interface Message<T, P> {
   type: T;
   // Can be a store address or an ipfs peer id
-  to: string;
+  to?: string;
   payload: P;
 }
 

--- a/src/Pinion.ts
+++ b/src/Pinion.ts
@@ -132,17 +132,16 @@ class Pinion {
     }
   };
 
-  private handleNewPeer = (peer: string): void => {
-    this.announce(peer).catch(logError);
+  private handleNewPeer = (): void => {
+    this.announce().catch(logError);
   };
 
-  private async announce(ipfsId?: string): Promise<void> {
+  private async announce(): Promise<void> {
     return this.ipfsNode.publish({
       type: ANNOUNCE_PINNER,
       payload: {
         ipfsId: await this.getId(),
       },
-      ...(ipfsId ? { to: ipfsId } : {}),
     });
   }
 
@@ -165,7 +164,7 @@ class Pinion {
     await this.ipfsNode.start();
     logDebug(`Pinner id: ${this.ipfsNode.id}`);
     await this.storeManager.start();
-    await this.announce();
+    await this.announce(); // Announce on start because the room may have peers already
   }
 
   public async getId(): Promise<string> {

--- a/src/Pinion.ts
+++ b/src/Pinion.ts
@@ -23,6 +23,7 @@ const { HAVE_HEADS, ANNOUNCE_PINNER } = PinnerActions;
 
 interface ClientActionPayload {
   ipfsHash?: string;
+  ipfsId?: string;
   address?: string;
 }
 
@@ -103,7 +104,7 @@ class Pinion {
 
     if (!action) return;
     const { type, payload } = action;
-    const { ipfsHash, address } = payload;
+    const { ipfsHash, ipfsId, address } = payload;
     switch (type) {
       case PIN_HASH: {
         if (!ipfsHash) {
@@ -127,12 +128,12 @@ class Pinion {
         break;
       }
       case ANNOUNCE_CLIENT: {
-        if (!address) {
-          logError('ANNOUNCE_CLIENT: no address given');
+        if (!ipfsId) {
+          logError('ANNOUNCE_CLIENT: no ipfsId given');
           return;
         }
         try {
-          await this.announce(address);
+          await this.announce(ipfsId);
         } catch (caughtError) {
           logError(caughtError);
         }
@@ -175,13 +176,13 @@ class Pinion {
     this.events.removeAllListeners();
   }
 
-  public async announce(address?: string): Promise<void> {
+  public async announce(ipfsId?: string): Promise<void> {
     return this.ipfsNode.publish({
       type: ANNOUNCE_PINNER,
       payload: {
-        address: await this.getId(),
+        ipfsId: await this.getId(),
       },
-      ...(address ? { to: address } : {}),
+      ...(ipfsId ? { to: ipfsId } : {}),
     });
   }
 }

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -17,7 +17,7 @@ import { ClientActions, PinnerActions } from '../actions';
 import AccessControllers from '../AccessControllers';
 import PermissiveAccessController from '../PermissiveAccessController';
 
-const { REPLICATE, PIN_HASH, ANNOUNCE_CLIENT } = ClientActions;
+const { REPLICATE, PIN_HASH } = ClientActions;
 const { HAVE_HEADS, ANNOUNCE_PINNER } = PinnerActions;
 
 const {
@@ -407,7 +407,7 @@ test('pinner responds upon client announcement event', async t => {
   const pinnerAnnounceAction = await pinnerAnnouncePromise;
   t.is(pinnerAnnounceAction.payload.ipfsId, pinnerId);
 
-  const clientAnnounceResponsePromise: Promise<{
+  const newPeerResponsePromise: Promise<{
     type: string;
     to: string;
     payload: { ipfsId: string };
@@ -418,15 +418,12 @@ test('pinner responds upon client announcement event', async t => {
     });
   });
 
-  await publishMessage(ipfs, room, {
-    type: ANNOUNCE_CLIENT,
-    payload: { ipfsId: 'client id' },
-  });
+  pinner.events.emit('pubsub:newpeer', 'client id');
 
-  // The pinner should announce itself in response to a client announcement
-  const clientAnnouncementResponse = await clientAnnounceResponsePromise;
-  t.is(clientAnnouncementResponse.payload.ipfsId, pinnerId);
-  t.is(clientAnnouncementResponse.to, 'client id');
+  // The pinner should announce itself in response to a new peer joining
+  const newPeerResponse = await newPeerResponsePromise;
+  t.is(newPeerResponse.payload.ipfsId, pinnerId);
+  t.is(newPeerResponse.to, 'client id');
 
   await ipfs.pubsub.unsubscribe(room, noop);
   roomMonitor.stop();

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -383,8 +383,8 @@ test('pinner caches stores and limit them to a pre-defined threshold', async t =
   return pinner.close();
 });
 
-test('pinner responds upon client announcement event', async t => {
-  const room = 'CLIENT_ANNOUNCEMENT_ROOM';
+test('pinner announces its presence to peers', async t => {
+  const room = 'PINNER_ANNOUNCEMENT_ROOM';
   const pinner = new Pinion(room, pinionOpts);
   const pinnerId = await pinner.getId();
   const { ipfs, teardown } = await getIPFSNode(pinnerId);
@@ -403,13 +403,12 @@ test('pinner responds upon client announcement event', async t => {
 
   await pinner.start();
 
-  // The pinner should have announced itself
+  // The pinner should have announced itself on start
   const pinnerAnnounceAction = await pinnerAnnouncePromise;
   t.is(pinnerAnnounceAction.payload.ipfsId, pinnerId);
 
   const newPeerResponsePromise: Promise<{
     type: string;
-    to: string;
     payload: { ipfsId: string };
   }> = new Promise(resolve => {
     ipfs.pubsub.subscribe(room, (msg: IPFS.PubsubMessage) => {
@@ -423,7 +422,6 @@ test('pinner responds upon client announcement event', async t => {
   // The pinner should announce itself in response to a new peer joining
   const newPeerResponse = await newPeerResponsePromise;
   t.is(newPeerResponse.payload.ipfsId, pinnerId);
-  t.is(newPeerResponse.to, 'client id');
 
   await ipfs.pubsub.unsubscribe(room, noop);
   roomMonitor.stop();

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -393,7 +393,7 @@ test('pinner responds upon client announcement event', async t => {
 
   const pinnerAnnouncePromise: Promise<{
     type: string;
-    payload: { address: string };
+    payload: { ipfsId: string };
   }> = new Promise(resolve => {
     ipfs.pubsub.subscribe(room, (msg: IPFS.PubsubMessage) => {
       const action = JSON.parse(msg.data.toString());
@@ -405,12 +405,12 @@ test('pinner responds upon client announcement event', async t => {
 
   // The pinner should have announced itself
   const pinnerAnnounceAction = await pinnerAnnouncePromise;
-  t.is(pinnerAnnounceAction.payload.address, pinnerId);
+  t.is(pinnerAnnounceAction.payload.ipfsId, pinnerId);
 
   const clientAnnounceResponsePromise: Promise<{
     type: string;
     to: string;
-    payload: { address: string };
+    payload: { ipfsId: string };
   }> = new Promise(resolve => {
     ipfs.pubsub.subscribe(room, (msg: IPFS.PubsubMessage) => {
       const action = JSON.parse(msg.data.toString());
@@ -420,13 +420,13 @@ test('pinner responds upon client announcement event', async t => {
 
   await publishMessage(ipfs, room, {
     type: ANNOUNCE_CLIENT,
-    payload: { address: 'client address' },
+    payload: { ipfsId: 'client id' },
   });
 
   // The pinner should announce itself in response to a client announcement
   const clientAnnouncementResponse = await clientAnnounceResponsePromise;
-  t.is(clientAnnouncementResponse.payload.address, pinnerId);
-  t.is(clientAnnouncementResponse.to, 'client address');
+  t.is(clientAnnouncementResponse.payload.ipfsId, pinnerId);
+  t.is(clientAnnouncementResponse.to, 'client id');
 
   await ipfs.pubsub.unsubscribe(room, noop);
   roomMonitor.stop();

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,5 +1,4 @@
 export enum ClientActions {
-  ANNOUNCE_CLIENT = 'ANNOUNCE_CLIENT',
   REPLICATE = 'REPLICATE',
   PIN_HASH = 'PIN_HASH',
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,8 +1,10 @@
 export enum ClientActions {
+  ANNOUNCE_CLIENT = 'ANNOUNCE_CLIENT',
   REPLICATE = 'REPLICATE',
   PIN_HASH = 'PIN_HASH',
 }
 
 export enum PinnerActions {
+  ANNOUNCE_PINNER = 'ANNOUNCE_PINNER',
   HAVE_HEADS = 'HAVE_HEADS',
 }


### PR DESCRIPTION
This PR adds presence announcements as a means to coordinate Pinion instances and newly-connecting clients without needing to specify pinner IDs on the client side.

* Add `ANNOUNCE_PINNER` action
* Pinion now listens for new peers joining and responds to them by announcing itself to the room
* Pinion now announces itself after starting
* Make `to` an optional field for `Message`