### PR TITLE
Better debug logging

### DIFF
--- a/src/AsyncLRU.ts
+++ b/src/AsyncLRU.ts
@@ -4,7 +4,6 @@
  */
 
 import Yallist = require('yallist');
-import debug = require('debug');
 
 type LoadFn<K, V> = (key: K) => Promise<V>;
 type RemoveFn<K, V> = (key: K, value: V | void) => Promise<void>;
@@ -21,8 +20,6 @@ interface Entry<K, V> {
   removing?: Promise<V | void>;
   afterRemoval?: () => Promise<V | void>;
 }
-
-const log = debug('pinner:lru');
 
 const createEntry = <K, V>(
   key: K,
@@ -69,7 +66,7 @@ class AsyncLRU<K, V> {
        * possible duplicates), so we sacrifice a predictable length for predictable
        * content
        */
-      if (this.llist.tail) this.del(this.llist.tail).catch(log);
+      if (this.llist.tail) this.del(this.llist.tail).catch(console.error);
     }
     return loading;
   }
@@ -120,7 +117,7 @@ class AsyncLRU<K, V> {
        * We could also throw here and bubble up to remove to let the outer
        * application decide what to do.
        */
-      log(caughtError);
+      console.error(caughtError);
     }
   }
 

--- a/src/StoreManager.ts
+++ b/src/StoreManager.ts
@@ -18,7 +18,7 @@ import PermissiveAccessController from './PermissiveAccessController';
 import IPFSNode from './IPFSNode';
 import AsyncLRU from './AsyncLRU';
 
-const log = debug('pinner:storeManager');
+const log = debug('pinion:storeManager');
 
 type StoreType = 'counter' | 'eventlog' | 'feed' | 'docstore' | 'keyvalue';
 
@@ -62,14 +62,14 @@ class StoreManager {
     store: OrbitDBStore | void,
   ): Promise<void> => {
     if (!store) {
-      return log(new Error(`Could not close store: ${address}`));
+      return console.error(new Error(`Could not close store: ${address}`));
     }
     return store.close();
   };
 
   private load = async (address: string): Promise<OrbitDBStore> => {
-    log(`Opening store with address ${address}`);
-    log(`Open stores: ${this.openStores}`);
+    log('Opening store with address %s', address);
+    log('Open stores: %d ', this.openStores);
     // I think this is done anyways by orbit, but just in case
     const pinHeadHash = (storeAddress: string, ipfsHash: string): void => {
       this.ipfsNode.pinHash(ipfsHash);


### PR DESCRIPTION
This PR adds a better differentiation between actual errors and things that are only debug output. Silencing the pinner should be possible now by just setting not setting a `DEBUG` environment variable.

To enable debug logging add `DEBUG=pinion:*` to your env vars. *Attention!* This changed from `pinner:*`.