### PR TITLE
Add webrtc transport option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@ node_modules
 yarn-error.log
 .env
 
-### IPFS node data
+### IPFS node data and config
 ipfs
+ipfsConfig.production.json
 
 ### orbit node data
 orbitdb*

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ipfs": "^0.36.4",
     "ipfs-pubsub-peer-monitor": "^0.0.8",
     "is-ipfs": "^0.6.0",
+    "libp2p-webrtc-star": "^0.16.1",
     "orbit-db": "^0.21.3",
     "wrtc": "^0.4.1",
     "yallist": "^3.0.3"

--- a/src/IPFSNode.ts
+++ b/src/IPFSNode.ts
@@ -10,8 +10,8 @@ import IPFS = require('ipfs');
 import EventEmitter = require('events');
 import debug = require('debug');
 import PeerMonitor = require('ipfs-pubsub-peer-monitor');
-import wrtc = require('wrtc');
-import WStar = require('libp2p-webrtc-star');
+
+import customLibp2pBundle from './customLibp2pBundle';
 
 interface Message<T, P> {
   type: T;
@@ -35,7 +35,6 @@ const configFile =
 const config = require(configFile);
 
 const log = debug('pinion:ipfs');
-const wstar = new WStar({ wrtc });
 
 class IPFSNode {
   private readonly events: EventEmitter;
@@ -61,12 +60,7 @@ class IPFSNode {
       init: { privateKey },
       config,
       EXPERIMENTAL: { pubsub: true },
-      libp2p: {
-        modules: {
-          transport: [wstar],
-          peerDiscovery: [wstar.discovery],
-        },
-      },
+      libp2p: customLibp2pBundle,
     });
     this.readyPromise = new Promise((resolve): void => {
       this.ipfs.on('ready', resolve);

--- a/src/IPFSNode.ts
+++ b/src/IPFSNode.ts
@@ -10,6 +10,8 @@ import IPFS = require('ipfs');
 import EventEmitter = require('events');
 import debug = require('debug');
 import PeerMonitor = require('ipfs-pubsub-peer-monitor');
+import wrtc = require('wrtc');
+import WStar = require('libp2p-webrtc-star');
 
 interface Message<T, P> {
   type: T;
@@ -33,6 +35,7 @@ const configFile =
 const config = require(configFile);
 
 const log = debug('pinion:ipfs');
+const wstar = new WStar({ wrtc });
 
 class IPFSNode {
   private readonly events: EventEmitter;
@@ -58,6 +61,12 @@ class IPFSNode {
       init: { privateKey },
       config,
       EXPERIMENTAL: { pubsub: true },
+      libp2p: {
+        modules: {
+          transport: [wstar],
+          peerDiscovery: [wstar.discovery],
+        },
+      },
     });
     this.readyPromise = new Promise((resolve): void => {
       this.ipfs.on('ready', resolve);

--- a/src/customLibp2pBundle.ts
+++ b/src/customLibp2pBundle.ts
@@ -1,0 +1,89 @@
+import Libp2p = require('libp2p');
+import TCP = require('libp2p-tcp');
+import MulticastDNS = require('libp2p-mdns');
+import WebSocketStarMulti = require('libp2p-websocket-star-multi');
+import KadDHT = require('libp2p-kad-dht');
+import MPLEX = require('pull-mplex');
+import SECIO = require('libp2p-secio');
+import multiaddr = require('multiaddr');
+import wrtc = require('wrtc');
+import WStar = require('libp2p-webrtc-star');
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createConfig = ({ peerInfo, peerBook }) => {
+  // Create our WebSocketStar transport and give it our PeerId, straight from the ipfs node
+  const wsstarServers = peerInfo.multiaddrs
+    .toArray()
+    .map(String)
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    .filter(addr => addr.includes('p2p-websocket-star'));
+  // the ws-star-multi module will replace this with the chosen ws-star servers
+  peerInfo.multiaddrs.replace(
+    wsstarServers.map(multiaddr),
+    '/p2p-websocket-star',
+  );
+  const wsstar = new WebSocketStarMulti({
+    servers: wsstarServers,
+    id: peerInfo.id,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    ignore_no_online: true,
+  });
+
+  const wStar = new WStar({ wrtc });
+
+  // Build and return our libp2p node
+  return new Libp2p({
+    peerInfo,
+    peerBook,
+    // Lets limit the connection managers peers and have it check peer health less frequently
+    connectionManager: {
+      minPeers: 25,
+      maxPeers: 100,
+      pollInterval: 5000,
+    },
+    modules: {
+      transport: [TCP, wsstar, wStar],
+      streamMuxer: [MPLEX],
+      connEncryption: [SECIO],
+      peerDiscovery: [MulticastDNS, wsstar.discovery, wStar.discovery],
+      dht: KadDHT,
+    },
+    config: {
+      peerDiscovery: {
+        autoDial: true, // auto dial to peers we find when we have less peers than `connectionManager.minPeers`
+        mdns: {
+          interval: 10000,
+          enabled: true,
+        },
+        bootstrap: {
+          // We're purposefully disabling bootstrap
+          interval: 30e3,
+          enabled: false,
+          list: [],
+        },
+      },
+      // Turn on relay with hop active so we can connect to more peers
+      relay: {
+        enabled: true,
+        hop: {
+          enabled: true,
+          active: true,
+        },
+      },
+      dht: {
+        enabled: false,
+        kBucketSize: 20,
+        randomWalk: {
+          enabled: false,
+          interval: 10e3, // This is set low intentionally, so more peers are discovered quickly. Higher intervals are recommended
+          timeout: 2e3, // End the query quickly since we're running so frequently
+        },
+      },
+      EXPERIMENTAL: {
+        pubsub: true,
+      },
+    },
+  });
+};
+
+export default createConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": ["es2018"],
     "allowSyntheticDefaultImports": true,
     "typeRoots": ["types", "node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noImplicitAny": false
   }
 }

--- a/types/libp2p-webrtc-star/index.d.ts
+++ b/types/libp2p-webrtc-star/index.d.ts
@@ -1,0 +1,15 @@
+interface Options {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  wrtc: any;
+}
+
+declare module 'libp2p-webrtc-star' {
+  class WStar {
+    constructor(options: Options);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    discovery: any;
+  }
+
+  export = WStar;
+}

--- a/types/wrtc/index.d.ts
+++ b/types/wrtc/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'wrtc' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const wrtc: any;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4462,7 +4462,6 @@ ipfs-http-client@^32.0.0:
 
 ipfs-http-client@ipfs/js-ipfs-http-client#master:
   version "33.1.1"
-  uid "339c4a729e4ea67ab692ccbd4ce53f6382a3cf82"
   resolved "https://codeload.github.com/ipfs/js-ipfs-http-client/tar.gz/339c4a729e4ea67ab692ccbd4ce53f6382a3cf82"
   dependencies:
     async "^2.6.1"
@@ -6097,7 +6096,7 @@ libp2p-tcp@~0.13.0:
     once "^1.4.0"
     stream-to-pull-stream "^1.7.2"
 
-libp2p-webrtc-star@~0.16.0:
+libp2p-webrtc-star@^0.16.1, libp2p-webrtc-star@~0.16.0:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/libp2p-webrtc-star/-/libp2p-webrtc-star-0.16.1.tgz#d160a157d033f1ad915cf460776a1ca32f352b75"
   integrity sha512-TLQ/Qhfx367kETt2pz2ejzVMB01PQjkBqxP+p+PD84N+JuFg3HVQw8jwXdiXexg/gKNMH+WwqVeWiKv/mVrCNA==


### PR DESCRIPTION
This PR adds the webrtc transport option, which enables the connection to a webrtc star.

To use it add the following line to your config:

```
Swarm: [ "/dns4/[IP_OF_THE_STAR]/tcp/9091/wss/p2p-webrtc-star"]
```