### PR TITLE
We need a `break`!

### DIFF
--- a/src/IPFSNode.ts
+++ b/src/IPFSNode.ts
@@ -81,7 +81,10 @@ class IPFSNode {
     // Don't handle messages from ourselves
     if (msg.from === this.id) return;
     log('New Message from: %s', msg.from);
-    log('%O', msg.data);
+    if (log.enabled) {
+      // Only stringify when absolutely necessary
+      log('%O', msg.data.toString());
+    }
     this.events.emit('pubsub:message', msg);
   };
 

--- a/src/Pinion.ts
+++ b/src/Pinion.ts
@@ -108,6 +108,7 @@ class Pinion {
         } catch (caughtError) {
           console.error(caughtError);
         }
+        break;
       }
       case PIN_HASH: {
         if (!ipfsHash) {

--- a/src/Pinion.ts
+++ b/src/Pinion.ts
@@ -94,8 +94,11 @@ class Pinion {
     let action: ClientAction | undefined;
     try {
       action = JSON.parse(message.data.toString());
-    } catch (e) {
-      log('Could not parse pinner message: %O', message.data);
+    } catch (caughtError) {
+      if (log.enabled) {
+        // Only stringify when absolutely necessary
+        log('Could not parse pinner message: %O', message.data.toString());
+      }
     }
 
     if (!action) return;
@@ -123,7 +126,10 @@ class Pinion {
       }
       case REPLICATE: {
         if (!address) {
-          log('REPLICATE: no address given: %O', message.data);
+          if (log.enabled) {
+            // Only stringify when absolutely necessary
+            log('REPLICATE: no address given: %O', message.data.toString());
+          }
           return;
         }
         try {

--- a/src/Pinion.ts
+++ b/src/Pinion.ts
@@ -111,7 +111,10 @@ class Pinion {
       }
       case PIN_HASH: {
         if (!ipfsHash) {
-          log('PIN_HASH: no ipfsHash given: %O', message.data);
+          if (log.enabled) {
+            // Only stringify when absolutely necessary
+            log('PIN_HASH: no ipfsHash given: %O', message.data.toString());
+          }
           return;
         }
         this.ipfsNode.pinHash(ipfsHash).catch(console.error);


### PR DESCRIPTION
This PR adds a `break` statement for the `ANNOUNCE_CLIENT` case to not fall through to the `PIN_HASH` case.

Also we're sneaking in a commit to improve the buffer logging in debug mode